### PR TITLE
Adding ability for children to directly reference other children

### DIFF
--- a/src/checkCSS.js
+++ b/src/checkCSS.js
@@ -38,13 +38,15 @@ function walkChildSelectors(callback, remainder, isParentConstrained) {
     var continueParsing = callback(childElement, childClass, isConstrained);
 
     while(/^\S/.test(trailer)) {
-        var modifierMatch = /^(?:\.-[a-z0-9-]+|::?[a-z-]+(?:\([^)]*\))?|\[[^\]]+\])(.*)$/.exec(trailer);
+        var modifierRegex = /^(?:\.-[a-z0-9-]+|::?[a-z-]+(?:\([^)]*\))?|\[[^\]]+\])(.*)$/,
+            directSemanticTagRegex = /^(?:\>(?!div)(?!span)[a-z0-9]+)(.*)$/;
+        var trailerMatch = modifierRegex.exec(trailer) || directSemanticTagRegex.exec(trailer);
 
-        if (!modifierMatch) {
-            throw new Error('invalid modifier: "' + trailer + '"');
+        if (!trailerMatch) {
+            throw new Error('invalid modifier or non-semantic tag: "' + trailer + '"');
         }
 
-        trailer = modifierMatch[1];
+        trailer = trailerMatch[1];
     }
 
     if (continueParsing && trailer !== '') {

--- a/test/basic.js
+++ b/test/basic.js
@@ -16,3 +16,7 @@ t.same(run('testtag {}'), [], 'global tag');
 t.same(run('.top-level-class {}'), [], 'top-level class');
 
 t.same(run('.-dangling-top-modifier {}'), [[1, 1, 'cannot recognize top-level selector match']], 'dangling top-level modifier');
+
+// child element direct child references
+t.same(run('.top-level ._child > h1 {}'), [], 'allow child classes to directly refer to element tags');
+t.same(run('.top-level ._child > div {}'), [[1, 1, 'do not use non-semantic tag name: "div"']], 'child classes can\'t directly refer to non-semantic element tags');


### PR DESCRIPTION
`.top-level ._child > ul` should be a valid selector in airtight, right?